### PR TITLE
Fix error when a thing's faction is null

### DIFF
--- a/Source/Stats/StatPart_Governance.cs
+++ b/Source/Stats/StatPart_Governance.cs
@@ -25,7 +25,7 @@ namespace Rimocracy
         float Multiplier(StatRequest req)
         {
             // Only applies to player's buildings and free colonists
-            if (!req.HasThing || !Utility.PoliticsEnabled || !((req.Thing is Pawn && (req.Thing as Pawn).IsCitizen()) || (req.Thing is Building && req.Thing.Faction.IsPlayer)))
+            if (!req.HasThing || !Utility.PoliticsEnabled || !((req.Thing is Pawn && ((Pawn)req.Thing).IsCitizen()) || (req.Thing is Building && req.Thing.Faction != null && req.Thing.Faction.IsPlayer)))
                 return 1;
             float effect = Utility.RimocracyComp.Governance;
 


### PR DESCRIPTION
In my heavily modded setup, sometimes, for some reason, `req.Thing.Faction` is null, which causes a null reference exception in this mod.

This fixes the error, nothing else seems to be affected.